### PR TITLE
Fix items for pull request

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,11 @@ pub use de::deserializer::Deserializer;
 pub use de::{from_bytes, from_bytes_cobs, take_from_bytes, take_from_bytes_cobs};
 pub use error::{Error, Result};
 pub use ser::{
-    flavors, serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs, to_stdvec,
-    to_stdvec_cobs, to_vec, to_vec_cobs,
+    flavors, serialize_with_flavor, serializer::Serializer, to_slice, to_slice_cobs,
+    to_vec, to_vec_cobs,
+};
+
+#[cfg(feature = "use-std")]
+pub use ser::{
+    to_stdvec, to_stdvec_cobs
 };

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -167,6 +167,7 @@ where
 /// let ser: Vec<u8> = to_stdvec("Hi!").unwrap();
 /// assert_eq!(ser.as_slice(), &[0x03, b'H', b'i', b'!']);
 /// ```
+#[cfg(feature = "use-std")]
 pub fn to_stdvec<T>(value: &T) -> Result<std::vec::Vec<u8>>
 where
     T: Serialize + ?Sized,

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -185,10 +185,10 @@ where
 /// use postcard::to_stdvec_cobs;
 ///
 /// let ser: Vec<u8> = to_stdvec_cobs(&true).unwrap();
-/// assert_eq!(ser.as_slice(), &[0x01]);
+/// assert_eq!(ser.as_slice(), &[0x02, 0x01, 0x00]);
 ///
 /// let ser: Vec<u8> = to_stdvec_cobs("Hi!").unwrap();
-/// assert_eq!(ser.as_slice(), &[0x03, b'H', b'i', b'!']);
+/// assert_eq!(ser.as_slice(), &[0x05, 0x03, b'H', b'i', b'!', 0x00]);
 /// ```
 #[cfg(feature = "use-std")]
 pub fn to_stdvec_cobs<T>(value: &T) -> Result<std::vec::Vec<u8>>


### PR DESCRIPTION
COBS adds/modifies some data so that you can use `0x00` as a termination character. The test values didn't take this into account, and were only the non-encoded values of the serialized data.

I also fixed a couple things that broke when you had default features enabled (without std).